### PR TITLE
feat(web): Add OHA hardware badge to header

### DIFF
--- a/apps/web/src/app/[lang]/page.tsx
+++ b/apps/web/src/app/[lang]/page.tsx
@@ -51,7 +51,8 @@ export default async function LandingPage({ params }: PageProps<"/[lang]">) {
       <header className="border-b border-zinc-800 bg-zinc-900/95 backdrop-blur">
         <div className="mx-auto flex max-w-7xl items-center justify-between px-8 py-3 sm:px-12">
           {/* Logo */}
-          <Link href={`/${lang}`} className="whitespace-nowrap font-mono text-xs font-bold tracking-widest text-amber-500 md:text-sm">
+          <Link href={`/${lang}`} className="flex items-center whitespace-nowrap font-mono text-xs font-bold tracking-widest text-amber-500 md:text-sm">
+            <span className="mr-3 bg-amber-500 px-2 py-0.5 text-xs font-bold tracking-widest text-black">OHA</span>
             {h.logo}
           </Link>
 


### PR DESCRIPTION
## Summary
- Add a solid amber `OHA` badge before the header logo text
- Styled as a manufacturer's asset tag (`bg-amber-500 text-black`) to reinforce the industrial hardware aesthetic
- Badge sits inline with the existing logo link

## Test plan
- [x] Verify badge renders correctly on desktop and mobile
- [x] Confirm the logo link still navigates to the locale root

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated header logo area layout and added a new "OHA" badge display with amber styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->