### PR TITLE
feat(web): Enable Vercel Analytics

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@open-ham-awards/contracts": "workspace:*",
+    "@vercel/analytics": "^2.0.1",
     "next": "16.2.3",
     "react": "19.2.4",
     "react-dom": "19.2.4"

--- a/apps/web/src/app/[lang]/layout.tsx
+++ b/apps/web/src/app/[lang]/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist_Mono, Inter } from "next/font/google";
+import { Analytics } from "@vercel/analytics/next";
 import { locales, hasLocale } from "./dictionaries";
 import { notFound } from "next/navigation";
 import "../globals.css";
@@ -37,6 +38,7 @@ export default async function RootLayout({
     <html lang={lang} className={`${inter.variable} ${geistMono.variable}`}>
       <body className="min-h-screen bg-zinc-900 text-zinc-200 antialiased">
         {children}
+        <Analytics />
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
We need visibility into traffic and web vitals now that the landing page
is live. This adds Vercel Analytics to the root layout so all locale
routes (/en, /es) are tracked automatically.

- Install `@vercel/analytics`
- Add `<Analytics />` component to the root layout

No configuration needed on the Vercel dashboard — it's auto-detected
from the package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added analytics tracking to monitor user interactions and application performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->